### PR TITLE
feat: update curated models with Claude 4.6, GPT-4.1/4o, and Gemini 3 GA

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -92,24 +92,49 @@ data:
         provider_params:
           model: openai/gpt-5-image-mini
 
+      - model_name: or-claude-opus-4.6 [EXTERNAL]
+        provider: openrouter
+        provider_params:
+          model: anthropic/claude-opus-4-6
+
+      - model_name: or-claude-sonnet-4.6 [EXTERNAL]
+        provider: openrouter
+        provider_params:
+          model: anthropic/claude-sonnet-4-6
+
+      - model_name: or-gpt-4.1 [EXTERNAL]
+        provider: openrouter
+        provider_params:
+          model: openai/gpt-4.1
+
+      - model_name: or-gpt-4o [EXTERNAL]
+        provider: openrouter
+        provider_params:
+          model: openai/gpt-4o
+
       # ==========================================================================
       # CUI-APPROVED (Google Vertex AI)
       # ==========================================================================
 
-      - model_name: gemini-3-flash-preview [CUI-APPROVED]
+      - model_name: gemini-3.1-pro-preview [CUI-APPROVED]
         provider: vertex_ai
         provider_params:
-          model: gemini-3-flash-preview
+          model: gemini-3.1-pro-preview
 
-      - model_name: gemini-3-pro-preview [CUI-APPROVED]
+      - model_name: gemini-3-flash [CUI-APPROVED]
         provider: vertex_ai
         provider_params:
-          model: gemini-3-pro-preview
+          model: gemini-3-flash
 
-      - model_name: gemini-3-pro-image-preview [CUI-APPROVED]
+      - model_name: gemini-3-pro [CUI-APPROVED]
         provider: vertex_ai
         provider_params:
-          model: gemini-3-pro-image-preview
+          model: gemini-3-pro
+
+      - model_name: gemini-3-pro-image [CUI-APPROVED]
+        provider: vertex_ai
+        provider_params:
+          model: gemini-3-pro-image
 
       - model_name: gemini-2.5-pro [CUI-APPROVED]
         provider: vertex_ai


### PR DESCRIPTION
## Summary
- Add new OpenRouter models: Claude Opus/Sonnet 4.6, GPT-4.1, GPT-4o
- Promote Gemini 3 preview models (flash, pro, pro-image) to GA
- Add Gemini 3.1 Pro Preview
- Keeps `configmap.yaml` defaults in sync with citadel `config/models.yaml`

Companion PR: https://github.com/radiusmethod/citadel/pull/106
Related issue: https://github.com/radiusmethod/citadel/issues/105

## Test plan
- [x] `helm template` renders valid YAML
- [x] Verify model list matches citadel `config/models.yaml`
- [x] Deploy to staging with default config and verify models

🤖 Generated with [Claude Code](https://claude.com/claude-code)