### PR TITLE
Clean up chart identity: radiusmethod→corveil + finish citadel→corveil rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug with the Citadel Helm chart
+description: Report a bug with the Corveil Helm chart
 labels: ["bug"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussion
-    url: https://github.com/radiusmethod/citadel-helm/discussions
+    url: https://github.com/corveil/corveil-helm/discussions
     about: Ask questions and discuss ideas in GitHub Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or improvement for the Citadel Helm chart
+description: Suggest a new feature or improvement for the Corveil Helm chart
 labels: ["enhancement"]
 body:
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,8 @@
 
 <!-- How did you test these changes? -->
 
-- [ ] `helm lint . --set citadel.secretKey=test` passes
-- [ ] `helm template citadel . --set citadel.secretKey=test` renders correctly
+- [ ] `helm lint . --set corveil.secretKey=test` passes
+- [ ] `helm template corveil . --set corveil.secretKey=test` renders correctly
 
 ## Checklist
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,13 +18,13 @@ jobs:
         run: helm dependency build .
 
       - name: Helm lint
-        run: helm lint . --set citadel.secretKey=test
+        run: helm lint . --set corveil.secretKey=test
 
       - name: Helm template
-        run: helm template citadel . --set citadel.secretKey=test
+        run: helm template corveil . --set corveil.secretKey=test
 
       - name: Render templates for kubelinter
-        run: helm template citadel . --set citadel.secretKey=test --output-dir rendered
+        run: helm template corveil . --set corveil.secretKey=test --output-dir rendered
 
       - name: Install kubelinter
         run: |
@@ -33,4 +33,4 @@ jobs:
           sudo mv kube-linter-linux /usr/local/bin/kube-linter
 
       - name: Run kubelinter
-        run: kube-linter lint rendered/citadel-chart/templates/
+        run: kube-linter lint rendered/corveil-chart/templates/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,12 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Update Chart.yaml version
+        # Only the chart `version` is derived from the git tag. `appVersion` is
+        # curated in Chart.yaml and tracks the Corveil app release independently
+        # (they are decoupled since 1.0.0), so it must NOT be rewritten here —
+        # doing so would point the default image tag at a non-existent app tag.
         run: |
           sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" Chart.yaml
 
       - name: Build chart dependencies
         run: helm dependency build .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,4 +38,4 @@ jobs:
         run: helm package .
 
       - name: Push chart to GHCR
-        run: helm push citadel-chart-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/radiusmethod/citadel-helm
+        run: helm push corveil-chart-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/corveil/corveil-helm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ change. See the upgrade note below.
 - **`fullnameOverride`**: `"citadel"` → `"corveil"`. Rendered resource names
   (Deployment, Service, ServiceAccount, Secret, ConfigMap, HPA, PDB,
   NetworkPolicy, VirtualService, test pod) change from `citadel*` to `corveil*`.
+- **`nameOverride`**: `""` → `"corveil"`, so the `app.kubernetes.io/name` selector
+  label is now `corveil` (was `citadel-chart`, i.e. `.Chart.Name`). This aligns the
+  label with the resource names and with the `kubectl -l app.kubernetes.io/name=corveil`
+  commands in the docs. Being a selector-label change, it carries the same
+  immutable-selector caveat on in-place upgrades — see the Upgrade note.
 - **Values block key**: top-level `citadel:` → `corveil:`. Every override keyed
   under `citadel:` moves accordingly (e.g. `citadel.secretKey` →
   `corveil.secretKey`, `citadel.okta.*` → `corveil.okta.*`).
@@ -44,6 +49,8 @@ change. See the upgrade note below.
   `TRUST_SOCKETZERO_JWT` / `SOCKETZERO_JWT_*` env vars). The current Corveil app
   binary does not consume these, so the block was dropped rather than carried as
   dead config; it can be reintroduced when the app ships SocketZero support.
+- **Dead `corveil.databaseUrl` template helper** (unused; `DATABASE_URL` is built
+  inline in the Secret).
 
 ### Added
 
@@ -63,10 +70,16 @@ resources. Recommended path:
    `istio.citadel:` → `istio.corveil:`. Env-var **names** are unchanged.
 2. Update the install source to
    `oci://ghcr.io/corveil/corveil-helm/corveil-chart`.
-3. Either reinstall fresh as the `corveil` release, or set
-   `--set fullnameOverride=citadel` to keep the old resource names during the
-   transition. The bundled-PostgreSQL PVC (`data-<release>-postgresql-0`) is not
-   renamed by this change.
+3. Either **reinstall fresh** as the `corveil` release (recommended — the name
+   change makes Helm create new resources and remove the old ones), **or** for an
+   in-place `helm upgrade`, pin *both* old identifiers so the immutable Deployment
+   selector does not change:
+   `--set fullnameOverride=citadel --set nameOverride=citadel-chart`.
+   `fullnameOverride` keeps the old resource names; `nameOverride` keeps the old
+   `app.kubernetes.io/name: citadel-chart` selector label. Omitting `nameOverride`
+   flips that label and `helm upgrade` fails with `field is immutable`. The
+   bundled-PostgreSQL PVC (`data-<release>-postgresql-0`) is not renamed by this
+   change.
 
 ## [0.2.1] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ change. See the upgrade note below.
 > still speaks `citadel` on the wire, so these are **kept as-is**: the
 > `apiKeyPrefix` default `sk-citadel`, the `x-citadel-api-key` passthrough header,
 > every rendered environment-variable **name** (`API_KEY_PREFIX`, `SECRET_KEY`,
-> `SOCKETZERO_JWT_AUDIENCE`, …), and the bundled PostgreSQL `database` /
+> `ENVIRONMENT`, …), and the bundled PostgreSQL `database` /
 > `username` / `password` defaults (`citadel`). `helm template` renders the exact
 > same env-var keys the app reads.
 
@@ -33,12 +33,17 @@ change. See the upgrade note below.
 - **Template helpers**: `citadel.*` named templates → `corveil.*`.
 - **`image.repository`**: `ghcr.io/radiusmethod/citadel` → `ghcr.io/corveil/corveil`.
   The Corveil app image now publishes to the `corveil` GHCR org.
-- **`socketzero.jwtAudience`** default: `"citadel"` → `"corveil"`, matching the
-  Corveil app's `SOCKETZERO_JWT_AUDIENCE` default.
 - **`appVersion`**: `0.2.1` → `0.3.4`, tracking the current Corveil app release.
 - **Branding**: README, docs, `LICENSE` (© 2026 Corveil, Inc.), `SECURITY.md`,
   `CONTRIBUTING.md`, `CODEOWNERS`, and issue templates repointed to
   `corveil/corveil-helm` / `corveil/corveil` / Corveil.
+
+### Removed
+
+- **SocketZero JWT authentication** (`socketzero.*` values and the
+  `TRUST_SOCKETZERO_JWT` / `SOCKETZERO_JWT_*` env vars). The current Corveil app
+  binary does not consume these, so the block was dropped rather than carried as
+  dead config; it can be reintroduced when the app ships SocketZero support.
 
 ### Upgrade
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,58 @@
 # Changelog
 
-All notable changes to the Citadel Helm chart will be documented in this file.
+All notable changes to the Corveil Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-07-21
+
+Rebrands the chart identity from **Citadel** to **Corveil**. This is a breaking
+change: the chart name, rendered resource names, and user-facing values keys all
+change. See the upgrade note below.
+
+> ⚠️ **On-the-wire / auth contract is intentionally unchanged.** The Corveil app
+> still speaks `citadel` on the wire, so these are **kept as-is**: the
+> `apiKeyPrefix` default `sk-citadel`, the `x-citadel-api-key` passthrough header,
+> every rendered environment-variable **name** (`API_KEY_PREFIX`, `SECRET_KEY`,
+> `SOCKETZERO_JWT_AUDIENCE`, …), and the bundled PostgreSQL `database` /
+> `username` / `password` defaults (`citadel`). `helm template` renders the exact
+> same env-var keys the app reads.
+
+### Changed (BREAKING)
+
+- **Chart name**: `citadel-chart` → `corveil-chart`. The published OCI artifact
+  moves to `oci://ghcr.io/corveil/corveil-helm/corveil-chart`.
+- **`fullnameOverride`**: `"citadel"` → `"corveil"`. Rendered resource names
+  (Deployment, Service, ServiceAccount, Secret, ConfigMap, HPA, PDB,
+  NetworkPolicy, VirtualService, test pod) change from `citadel*` to `corveil*`.
+- **Values block key**: top-level `citadel:` → `corveil:`. Every override keyed
+  under `citadel:` moves accordingly (e.g. `citadel.secretKey` →
+  `corveil.secretKey`, `citadel.okta.*` → `corveil.okta.*`).
+- **Istio block key**: `istio.citadel:` → `istio.corveil:` (gateways/hosts).
+- **Template helpers**: `citadel.*` named templates → `corveil.*`.
+- **`image.repository`**: `ghcr.io/radiusmethod/citadel` → `ghcr.io/corveil/corveil`.
+  The Corveil app image now publishes to the `corveil` GHCR org.
+- **`socketzero.jwtAudience`** default: `"citadel"` → `"corveil"`, matching the
+  Corveil app's `SOCKETZERO_JWT_AUDIENCE` default.
+- **`appVersion`**: `0.2.1` → `0.3.4`, tracking the current Corveil app release.
+- **Branding**: README, docs, `LICENSE` (© 2026 Corveil, Inc.), `SECURITY.md`,
+  `CONTRIBUTING.md`, `CODEOWNERS`, and issue templates repointed to
+  `corveil/corveil-helm` / `corveil/corveil` / Corveil.
+
+### Upgrade
+
+Because resource names change, an in-place `helm upgrade` will try to replace
+resources. Recommended path:
+
+1. Migrate `values.yaml` overrides: `citadel:` → `corveil:` and
+   `istio.citadel:` → `istio.corveil:`. Env-var **names** are unchanged.
+2. Update the install source to
+   `oci://ghcr.io/corveil/corveil-helm/corveil-chart`.
+3. Either reinstall fresh as the `corveil` release, or set
+   `--set fullnameOverride=citadel` to keep the old resource names during the
+   transition. The bundled-PostgreSQL PVC (`data-<release>-postgresql-0`) is not
+   renamed by this change.
 
 ## [0.2.1] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ change. See the upgrade note below.
   binary does not consume these, so the block was dropped rather than carried as
   dead config; it can be reintroduced when the app ships SocketZero support.
 
+### Added
+
+- **Migration guards.** The chart now `fail`s at template time with a clear,
+  actionable message if a stale `citadel:` / `istio.citadel:` / `socketzero:`
+  override key is still present, and `corveil.secretKey` is `required` when
+  `existingSecret` is unset. This turns the breaking key rename into a loud error
+  instead of a silently mis-secreted deploy (an ignored `citadel.secretKey`
+  rendering an empty `SECRET_KEY`). Safe to remove after the 1.x line.
+
 ### Upgrade
 
 Because resource names change, an in-place `helm upgrade` will try to replace

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for all files
-* @corveil/engineering
+* @dhilgaertner

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code owners for all files
-* @radiusmethod/engineering
+* @corveil/engineering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Citadel Helm Chart
+# Contributing to Corveil Helm Chart
 
-Thank you for your interest in contributing to the Citadel Helm chart.
+Thank you for your interest in contributing to the Corveil Helm chart.
 
 ## Getting Started
 
@@ -14,8 +14,8 @@ Thank you for your interest in contributing to the Citadel Helm chart.
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/radiusmethod/citadel-helm.git
-   cd citadel-helm
+   git clone https://github.com/corveil/corveil-helm.git
+   cd corveil-helm
    ```
 
 2. Update chart dependencies:
@@ -35,7 +35,7 @@ Thank you for your interest in contributing to the Citadel Helm chart.
 
 ## Bug Reports
 
-Open a [GitHub issue](https://github.com/radiusmethod/citadel-helm/issues/new) with:
+Open a [GitHub issue](https://github.com/corveil/corveil-helm/issues/new) with:
 
 - Chart version and Kubernetes version
 - `values.yaml` overrides used (redact secrets)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
-name: citadel-chart
-description: Helm chart for Citadel AI Gateway. Big Bang ready.
+name: corveil-chart
+description: Helm chart for Corveil AI Gateway. Big Bang ready.
 type: application
 
 # Chart version — increment on each release
-version: 0.2.1
+version: 1.0.0
 
 # Application version deployed by this chart
-appVersion: "0.2.1"
+appVersion: "0.3.4"
 
 dependencies:
   - name: postgresql

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Radius Method
+Copyright (c) 2026 Corveil, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Citadel Helm Chart
+# Corveil Helm Chart
 
-Helm chart for [Citadel AI Gateway](https://github.com/radiusmethod/citadel) — a zero-trust AI gateway with spend tracking, guardrails, and OpenAI-compatible API.
+Helm chart for [Corveil AI Gateway](https://github.com/corveil/corveil) — a zero-trust AI gateway with spend tracking, guardrails, and OpenAI-compatible API.
 
 Works as a standalone Kubernetes install **and** as a Big Bang package.
 
 ## Quick Start
 
 ```bash
-helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
-  --set citadel.secretKey="$(openssl rand -hex 32)" \
-  --set citadel.environment=development \
-  --set citadel.devLoginEnabled=true \
+helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+  --set corveil.secretKey="$(openssl rand -hex 32)" \
+  --set corveil.environment=development \
+  --set corveil.devLoginEnabled=true \
   --set providers.openrouter.apiKey="sk-or-xxx"
 ```
 
@@ -19,7 +19,7 @@ helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
 Port-forward and open the UI:
 
 ```bash
-kubectl port-forward svc/citadel 8000:8000
+kubectl port-forward svc/corveil 8000:8000
 open http://localhost:8000/ui
 ```
 
@@ -40,28 +40,28 @@ Click **Dev Login** to get started immediately — no OIDC setup required.
 
 ### Evaluation Mode
 
-For trying out Citadel before production deployment. Enables the dev login UI so you can create users and API keys without configuring OIDC.
+For trying out Corveil before production deployment. Enables the dev login UI so you can create users and API keys without configuring OIDC.
 
 ```bash
-helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
-  --set citadel.secretKey="change-me" \
-  --set citadel.environment=development \
-  --set citadel.devLoginEnabled=true \
+helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+  --set corveil.secretKey="change-me" \
+  --set corveil.environment=development \
+  --set corveil.devLoginEnabled=true \
   --set providers.openrouter.apiKey="sk-or-xxx"
 ```
 
-This deploys Citadel with the bundled PostgreSQL, development mode, and dev login enabled.
+This deploys Corveil with the bundled PostgreSQL, development mode, and dev login enabled.
 
 ### Production (external database)
 
 ```bash
-helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
-  --set citadel.secretKey="$(openssl rand -hex 32)" \
-  --set citadel.okta.enabled=true \
-  --set citadel.okta.domain="company.okta.com" \
-  --set citadel.okta.clientId="0oaXXX" \
-  --set citadel.okta.clientSecret="secret" \
-  --set citadel.okta.sessionSecret="$(openssl rand -hex 32)" \
+helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+  --set corveil.secretKey="$(openssl rand -hex 32)" \
+  --set corveil.okta.enabled=true \
+  --set corveil.okta.domain="company.okta.com" \
+  --set corveil.okta.clientId="0oaXXX" \
+  --set corveil.okta.clientSecret="secret" \
+  --set corveil.okta.sessionSecret="$(openssl rand -hex 32)" \
   --set postgresql.enabled=false \
   --set externalDatabase.url="postgresql://user:pass@db-host:5432/citadel" \
   --set providers.openrouter.apiKey="sk-or-xxx"
@@ -72,17 +72,17 @@ helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
 ```yaml
 # In your Big Bang values override:
 addons:
-  citadel:
+  corveil:
     enabled: true
     values:
       istio:
         enabled: true
-        citadel:
+        corveil:
           gateways:
             - "istio-system/public"
           hosts:
-            - "citadel.bigbang.dev"
-      citadel:
+            - "corveil.bigbang.dev"
+      corveil:
         secretKey: "change-me"
       providers:
         openrouter:
@@ -94,8 +94,8 @@ addons:
 If you manage secrets externally (Vault, Sealed Secrets, ESO), create a Kubernetes Secret with the expected keys and reference it:
 
 ```bash
-helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
-  --set existingSecret=my-citadel-secrets
+helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+  --set existingSecret=my-corveil-secrets
 ```
 
 Required keys in your secret: `DATABASE_URL`, `SECRET_KEY`. Optional: `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.
@@ -104,17 +104,17 @@ Required keys in your secret: `DATABASE_URL`, `SECRET_KEY`. Optional: `OPENROUTE
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Container image | `ghcr.io/radiusmethod/citadel` |
+| `image.repository` | Container image | `ghcr.io/corveil/corveil` |
 | `image.tag` | Image tag (defaults to appVersion) | `""` |
-| `citadel.secretKey` | Session signing key (**required**) | `""` |
-| `citadel.environment` | `development`, `staging`, or `production` | `production` |
-| `citadel.devLoginEnabled` | Enable dev login bypass | `false` |
-| `citadel.logLevel` | Log level | `INFO` |
-| `citadel.autoProvisionUsers` | Auto-create users from headers | `true` |
-| `citadel.guardrails.enabled` | Enable guardrails | `true` |
-| `citadel.passthrough.enabled` | Enable API key passthrough | `true` |
-| `citadel.plugins.enabled` | Enable plugin system | `true` |
-| `citadel.okta.enabled` | Enable Okta OIDC | `false` |
+| `corveil.secretKey` | Session signing key (**required**) | `""` |
+| `corveil.environment` | `development`, `staging`, or `production` | `production` |
+| `corveil.devLoginEnabled` | Enable dev login bypass | `false` |
+| `corveil.logLevel` | Log level | `INFO` |
+| `corveil.autoProvisionUsers` | Auto-create users from headers | `true` |
+| `corveil.guardrails.enabled` | Enable guardrails | `true` |
+| `corveil.passthrough.enabled` | Enable API key passthrough | `true` |
+| `corveil.plugins.enabled` | Enable plugin system | `true` |
+| `corveil.okta.enabled` | Enable Okta OIDC | `false` |
 | `providers.openrouter.apiKey` | OpenRouter API key | `""` |
 | `providers.anthropic.apiKey` | Anthropic API key | `""` |
 | `providers.vertexai.projectId` | GCP project ID | `""` |
@@ -135,7 +135,7 @@ For the complete configuration reference, see [docs/CONFIGURATION.md](docs/CONFI
 ### Claude Code
 
 ```bash
-claude config set --global apiBaseUrl http://<citadel-host>:8000/v1
+claude config set --global apiBaseUrl http://<corveil-host>:8000/v1
 ```
 
 ### OpenAI SDK / Python
@@ -143,16 +143,16 @@ claude config set --global apiBaseUrl http://<citadel-host>:8000/v1
 ```python
 from openai import OpenAI
 client = OpenAI(
-    base_url="http://<citadel-host>:8000/v1",
-    api_key="<your-citadel-api-key>",
+    base_url="http://<corveil-host>:8000/v1",
+    api_key="<your-corveil-api-key>",
 )
 ```
 
 ### curl
 
 ```bash
-curl http://<citadel-host>:8000/v1/chat/completions \
-  -H "Authorization: Bearer <your-citadel-api-key>" \
+curl http://<corveil-host>:8000/v1/chat/completions \
+  -H "Authorization: Bearer <your-corveil-api-key>" \
   -H "Content-Type: application/json" \
   -d '{"model": "or-claude-sonnet-4.5 [EXTERNAL]", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
@@ -166,13 +166,13 @@ The migration runner is idempotent and tracks state in a `schema_migrations` tab
 ## Uninstall
 
 ```bash
-helm uninstall citadel
+helm uninstall corveil
 ```
 
 Note: The bundled PostgreSQL PVC is **not** deleted automatically. To fully clean up:
 
 ```bash
-kubectl delete pvc data-citadel-postgresql-0
+kubectl delete pvc data-corveil-postgresql-0
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ Click **Dev Login** to get started immediately — no OIDC setup required.
 
 - Kubernetes 1.23+
 - Helm 3.10+
+- **Pull access to the Corveil image.** The default image
+  (`ghcr.io/corveil/corveil`) is a **private** package. Create an image pull
+  secret and reference it so the cluster can pull it:
+
+  ```bash
+  kubectl create secret docker-registry corveil-ghcr \
+    --docker-server=ghcr.io \
+    --docker-username=<github-user> \
+    --docker-password=<github-token-with-read:packages>
+
+  helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+    --set imagePullSecrets[0].name=corveil-ghcr \
+    ...
+  ```
+
+  Skip this only if you override `image.repository` to an image your cluster can already pull.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 1.0.x   | Yes       |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,7 @@
 | Version | Supported |
 |---------|-----------|
 | 1.0.x   | Yes       |
+| 0.2.x   | Yes       |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in this Helm chart, please report it re
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email [security@radiusmethod.com](mailto:security@radiusmethod.com) with:
+Instead, please email [contact@corveil.com](mailto:contact@corveil.com) with:
 
 - A description of the vulnerability
 - Steps to reproduce
@@ -27,14 +27,14 @@ Instead, please email [security@radiusmethod.com](mailto:security@radiusmethod.c
 
 ## Scope
 
-This policy covers the Helm chart templates, default configurations, and documentation in this repository. For vulnerabilities in the Citadel application itself, please report to the [Citadel repository](https://github.com/radiusmethod/citadel).
+This policy covers the Helm chart templates, default configurations, and documentation in this repository. For vulnerabilities in the Corveil application itself, please report to the [Corveil repository](https://github.com/corveil/corveil).
 
 ## Best Practices
 
-When deploying Citadel, we recommend:
+When deploying Corveil, we recommend:
 
-- Always set a strong `citadel.secretKey` (use `openssl rand -hex 32`)
-- Disable `citadel.devLoginEnabled` in production
+- Always set a strong `corveil.secretKey` (use `openssl rand -hex 32`)
+- Disable `corveil.devLoginEnabled` in production
 - Use `existingSecret` with a secrets manager (Vault, Sealed Secrets, ESO) for sensitive values
 - Enable network policies in production clusters
 - Use TLS termination via Ingress or Istio

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -117,13 +117,11 @@ Corveil supports multiple authentication methods, evaluated in priority order:
 
 1. **Passthrough** — If `x-citadel-api-key` header is present and passthrough is enabled, the client's `Authorization` header is forwarded to the upstream provider. The Corveil key is used for logging and budget tracking.
 
-2. **SocketZero JWT** — If enabled, verifies RS256-signed JWTs from SocketZero Receiver. Users are auto-provisioned on first auth.
+2. **API Key** — Traditional `sk-citadel-xxx` virtual API keys. Keys are SHA-256 hashed before storage.
 
-3. **API Key** — Traditional `sk-citadel-xxx` virtual API keys. Keys are SHA-256 hashed before storage.
+3. **OIDC (Okta)** — For the management UI. Users authenticate via Okta and get session cookies.
 
-4. **OIDC (Okta)** — For the management UI. Users authenticate via Okta and get session cookies.
-
-5. **Dev Login** — Bypass authentication for evaluation. Must be explicitly enabled.
+4. **Dev Login** — Bypass authentication for evaluation. Must be explicitly enabled.
 
 ## Database Schema
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,10 +1,10 @@
 # Architecture Overview
 
-This document describes the Citadel AI Gateway architecture for operators and platform engineers deploying the system.
+This document describes the Corveil AI Gateway architecture for operators and platform engineers deploying the system.
 
-## What is Citadel?
+## What is Corveil?
 
-Citadel is a zero-trust AI gateway that sits between your users (developers using Claude Code, OpenAI SDK, etc.) and LLM providers (OpenRouter, Anthropic, Vertex AI, AWS Bedrock). It provides:
+Corveil is a zero-trust AI gateway that sits between your users (developers using Claude Code, OpenAI SDK, etc.) and LLM providers (OpenRouter, Anthropic, Vertex AI, AWS Bedrock). It provides:
 
 - **Centralized API key management** — Users get virtual API keys; real provider keys stay in the gateway
 - **Spend tracking and budget enforcement** — Per-user and per-key cost monitoring with configurable limits
@@ -17,7 +17,7 @@ Citadel is a zero-trust AI gateway that sits between your users (developers usin
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│                          CITADEL GATEWAY                              │
+│                          CORVEIL GATEWAY                              │
 ├──────────────────────────────────────────────────────────────────────┤
 │                                                                       │
 │   Client Request (Claude Code / OpenAI SDK / curl)                   │
@@ -113,9 +113,9 @@ Citadel is a zero-trust AI gateway that sits between your users (developers usin
 
 ## Authentication Chain
 
-Citadel supports multiple authentication methods, evaluated in priority order:
+Corveil supports multiple authentication methods, evaluated in priority order:
 
-1. **Passthrough** — If `x-citadel-api-key` header is present and passthrough is enabled, the client's `Authorization` header is forwarded to the upstream provider. The Citadel key is used for logging and budget tracking.
+1. **Passthrough** — If `x-citadel-api-key` header is present and passthrough is enabled, the client's `Authorization` header is forwarded to the upstream provider. The Corveil key is used for logging and budget tracking.
 
 2. **SocketZero JWT** — If enabled, verifies RS256-signed JWTs from SocketZero Receiver. Users are auto-provisioned on first auth.
 
@@ -127,7 +127,7 @@ Citadel supports multiple authentication methods, evaluated in priority order:
 
 ## Database Schema
 
-Citadel uses PostgreSQL with four core tables:
+Corveil uses PostgreSQL with four core tables:
 
 ### users
 
@@ -195,7 +195,7 @@ Models are curated via `models.yaml` (ConfigMap). When `model_curation_enabled: 
 
 ## Plugin System
 
-Citadel has an extensible plugin system with lifecycle hooks:
+Corveil has an extensible plugin system with lifecycle hooks:
 
 ```
 Auth → PRE_REQUEST → CHECK_INPUT → PRE_PROVIDER → Provider Call
@@ -242,7 +242,7 @@ The chart creates these resources:
 
 | Resource | Condition | Purpose |
 |----------|-----------|---------|
-| Deployment | Always | Citadel application pods |
+| Deployment | Always | Corveil application pods |
 | Service (ClusterIP) | Always | Internal service |
 | ConfigMap (`-env`) | Always | Non-sensitive environment variables |
 | ConfigMap (`-models`) | Always | Models configuration |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,18 +78,6 @@ Rate limits can also be set per-key when creating API keys via the management AP
 
 Enabling body logging significantly increases storage usage but provides a full audit trail.
 
-## SocketZero JWT Authentication
-
-Keyless authentication via signed JWTs from SocketZero Receiver.
-
-| Parameter | Description | Default | Env Var |
-|-----------|-------------|---------|---------|
-| `socketzero.enabled` | Enable SocketZero JWT authentication | `false` | `TRUST_SOCKETZERO_JWT` |
-| `socketzero.jwtPublicKey` | PEM-encoded RS256 public key for JWT verification | `""` | `SOCKETZERO_JWT_PUBLIC_KEY` |
-| `socketzero.jwtHeader` | HTTP header containing the JWT | `"X-SocketZero-Jwt-Assertion"` | `SOCKETZERO_JWT_HEADER` |
-| `socketzero.jwtAudience` | Expected JWT audience claim | `"corveil"` | `SOCKETZERO_JWT_AUDIENCE` |
-| `socketzero.jwtIssuer` | Expected JWT issuer claim | `"socketzero"` | `SOCKETZERO_JWT_ISSUER` |
-
 ## LLM Providers
 
 ### OpenRouter
@@ -145,7 +133,6 @@ Optional keys:
 - `OKTA_CLIENT_SECRET`
 - `UI_SESSION_SECRET`
 - `REDIS_URL`
-- `SOCKETZERO_JWT_PUBLIC_KEY`
 
 ## Database
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -10,7 +10,7 @@ Complete reference for all `values.yaml` parameters in the Corveil Helm chart.
 | `image.repository` | Container image repository | `ghcr.io/corveil/corveil` | — |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` | — |
 | `image.tag` | Image tag (defaults to chart `appVersion`) | `""` | — |
-| `nameOverride` | Override the chart name | `""` | — |
+| `nameOverride` | `app.kubernetes.io/name` label value. Changing it on an existing release alters the immutable Deployment selector — see CHANGELOG [1.0.0] Upgrade. | `"corveil"` | — |
 | `fullnameOverride` | Override the full resource name | `"corveil"` | — |
 | `domain` | Base domain for Big Bang integration | `"bigbang.dev"` | — |
 | `imagePullSecrets` | Image pull secrets for private registries | `[]` | — |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,64 +1,64 @@
 # Configuration Reference
 
-Complete reference for all `values.yaml` parameters in the Citadel Helm chart.
+Complete reference for all `values.yaml` parameters in the Corveil Helm chart.
 
 ## Core Settings
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `replicaCount` | Number of Citadel pod replicas | `1` | — |
-| `image.repository` | Container image repository | `ghcr.io/radiusmethod/citadel` | — |
+| `replicaCount` | Number of Corveil pod replicas | `1` | — |
+| `image.repository` | Container image repository | `ghcr.io/corveil/corveil` | — |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` | — |
 | `image.tag` | Image tag (defaults to chart `appVersion`) | `""` | — |
 | `nameOverride` | Override the chart name | `""` | — |
-| `fullnameOverride` | Override the full resource name | `"citadel"` | — |
+| `fullnameOverride` | Override the full resource name | `"corveil"` | — |
 | `domain` | Base domain for Big Bang integration | `"bigbang.dev"` | — |
 | `imagePullSecrets` | Image pull secrets for private registries | `[]` | — |
 
-## Citadel Application
+## Corveil Application
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `citadel.environment` | Application environment (`development`, `staging`, `production`) | `production` | `ENVIRONMENT` |
-| `citadel.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` | `LOG_LEVEL` |
-| `citadel.secretKey` | Secret key for signing sessions and tokens (**required**) | `""` | `SECRET_KEY` |
-| `citadel.apiKeyPrefix` | Prefix for generated API keys | `"sk-citadel"` | `API_KEY_PREFIX` |
-| `citadel.autoProvisionUsers` | Auto-create users on first authentication | `true` | `AUTO_PROVISION_USERS` |
-| `citadel.devLoginEnabled` | Enable dev login bypass (disable in production) | `false` | `DEV_LOGIN_ENABLED` |
+| `corveil.environment` | Application environment (`development`, `staging`, `production`) | `production` | `ENVIRONMENT` |
+| `corveil.logLevel` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` | `LOG_LEVEL` |
+| `corveil.secretKey` | Secret key for signing sessions and tokens (**required**) | `""` | `SECRET_KEY` |
+| `corveil.apiKeyPrefix` | Prefix for generated API keys | `"sk-citadel"` | `API_KEY_PREFIX` |
+| `corveil.autoProvisionUsers` | Auto-create users on first authentication | `true` | `AUTO_PROVISION_USERS` |
+| `corveil.devLoginEnabled` | Enable dev login bypass (disable in production) | `false` | `DEV_LOGIN_ENABLED` |
 
 ### Guardrails
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `citadel.guardrails.enabled` | Enable the guardrails system | `true` | `GUARDRAILS_ENABLED` |
-| `citadel.guardrails.openaiModeration` | Enable OpenAI moderation API guardrail | `true` | `GUARDRAIL_OPENAI_MODERATION` |
-| `citadel.guardrails.piiFilter` | Enable PII detection and filtering | `false` | `GUARDRAIL_PII_FILTER` |
+| `corveil.guardrails.enabled` | Enable the guardrails system | `true` | `GUARDRAILS_ENABLED` |
+| `corveil.guardrails.openaiModeration` | Enable OpenAI moderation API guardrail | `true` | `GUARDRAIL_OPENAI_MODERATION` |
+| `corveil.guardrails.piiFilter` | Enable PII detection and filtering | `false` | `GUARDRAIL_PII_FILTER` |
 
 ### Passthrough
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `citadel.passthrough.enabled` | Enable passthrough mode for client-provided auth | `true` | `PASSTHROUGH_ENABLED` |
+| `corveil.passthrough.enabled` | Enable passthrough mode for client-provided auth | `true` | `PASSTHROUGH_ENABLED` |
 
-When passthrough is enabled, clients can send their own LLM provider credentials via the `Authorization` header while using a Citadel key in `x-citadel-api-key` for gateway authentication. Useful for Claude Code Max users.
+When passthrough is enabled, clients can send their own LLM provider credentials via the `Authorization` header while using a Corveil key in `x-citadel-api-key` for gateway authentication. Useful for Claude Code Max users.
 
 ### Plugins
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `citadel.plugins.enabled` | Enable the plugin system | `true` | `PLUGINS_ENABLED` |
+| `corveil.plugins.enabled` | Enable the plugin system | `true` | `PLUGINS_ENABLED` |
 
 ### Okta / OIDC
 
 | Parameter | Description | Default | Env Var |
 |-----------|-------------|---------|---------|
-| `citadel.okta.enabled` | Enable Okta OIDC authentication | `false` | — |
-| `citadel.okta.domain` | Okta domain (e.g., `company.okta.com`) | `""` | `OKTA_DOMAIN` |
-| `citadel.okta.clientId` | Okta OAuth client ID | `""` | `OKTA_CLIENT_ID` |
-| `citadel.okta.clientSecret` | Okta OAuth client secret | `""` | `OKTA_CLIENT_SECRET` |
-| `citadel.okta.sessionSecret` | Secret for encrypting UI sessions | `""` | `UI_SESSION_SECRET` |
-| `citadel.okta.sessionExpiryHours` | Session expiry in hours | `24` | `UI_SESSION_EXPIRY_HOURS` |
-| `citadel.okta.baseUrl` | Base URL for OIDC redirect (if behind proxy) | `""` | `UI_BASE_URL` |
+| `corveil.okta.enabled` | Enable Okta OIDC authentication | `false` | — |
+| `corveil.okta.domain` | Okta domain (e.g., `company.okta.com`) | `""` | `OKTA_DOMAIN` |
+| `corveil.okta.clientId` | Okta OAuth client ID | `""` | `OKTA_CLIENT_ID` |
+| `corveil.okta.clientSecret` | Okta OAuth client secret | `""` | `OKTA_CLIENT_SECRET` |
+| `corveil.okta.sessionSecret` | Secret for encrypting UI sessions | `""` | `UI_SESSION_SECRET` |
+| `corveil.okta.sessionExpiryHours` | Session expiry in hours | `24` | `UI_SESSION_EXPIRY_HOURS` |
+| `corveil.okta.baseUrl` | Base URL for OIDC redirect (if behind proxy) | `""` | `UI_BASE_URL` |
 
 ## Rate Limiting
 
@@ -87,7 +87,7 @@ Keyless authentication via signed JWTs from SocketZero Receiver.
 | `socketzero.enabled` | Enable SocketZero JWT authentication | `false` | `TRUST_SOCKETZERO_JWT` |
 | `socketzero.jwtPublicKey` | PEM-encoded RS256 public key for JWT verification | `""` | `SOCKETZERO_JWT_PUBLIC_KEY` |
 | `socketzero.jwtHeader` | HTTP header containing the JWT | `"X-SocketZero-Jwt-Assertion"` | `SOCKETZERO_JWT_HEADER` |
-| `socketzero.jwtAudience` | Expected JWT audience claim | `"citadel"` | `SOCKETZERO_JWT_AUDIENCE` |
+| `socketzero.jwtAudience` | Expected JWT audience claim | `"corveil"` | `SOCKETZERO_JWT_AUDIENCE` |
 | `socketzero.jwtIssuer` | Expected JWT issuer claim | `"socketzero"` | `SOCKETZERO_JWT_ISSUER` |
 
 ## LLM Providers
@@ -202,8 +202,8 @@ For full Bitnami Redis options, see the [Bitnami Redis chart docs](https://githu
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `istio.enabled` | Enable Istio VirtualService | `false` |
-| `istio.citadel.gateways` | Istio gateways | `["istio-system/public"]` |
-| `istio.citadel.hosts` | VirtualService hosts | `["citadel.{{ .Values.domain }}"]` |
+| `istio.corveil.gateways` | Istio gateways | `["istio-system/public"]` |
+| `istio.corveil.hosts` | VirtualService hosts | `["corveil.{{ .Values.domain }}"]` |
 | `istio.mtls.mode` | mTLS mode | `STRICT` |
 
 ### NetworkPolicy
@@ -267,9 +267,9 @@ When enabled, creates a NetworkPolicy allowing inbound HTTP (8000), and outbound
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `extraEnv` | Additional environment variables for the Citadel container | `[]` |
+| `extraEnv` | Additional environment variables for the Corveil container | `[]` |
 | `extraVolumes` | Additional volumes to add to the pod | `[]` |
-| `extraVolumeMounts` | Additional volume mounts for the Citadel container | `[]` |
+| `extraVolumeMounts` | Additional volume mounts for the Corveil container | `[]` |
 
 Example:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -7,6 +7,19 @@ This guide walks you through deploying Corveil AI Gateway on Kubernetes and conf
 - **Kubernetes cluster** (1.23+) with `kubectl` configured
 - **Helm** 3.10+
 - **At least one LLM provider API key** (OpenRouter recommended for quickest setup)
+- **Pull access to the Corveil image.** The default image `ghcr.io/corveil/corveil`
+  is a **private** GHCR package. Create a pull secret and pass it to the chart via
+  `imagePullSecrets` (see below), or override `image.repository` with an image your
+  cluster can already pull.
+
+  ```bash
+  kubectl create secret docker-registry corveil-ghcr \
+    --docker-server=ghcr.io \
+    --docker-username=<github-user> \
+    --docker-password=<github-token-with-read:packages>
+  ```
+
+  Then add `--set imagePullSecrets[0].name=corveil-ghcr` to the install commands below.
 
 ## Step 1: Install the Chart
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
-# Getting Started with Citadel
+# Getting Started with Corveil
 
-This guide walks you through deploying Citadel AI Gateway on Kubernetes and configuring clients to use it.
+This guide walks you through deploying Corveil AI Gateway on Kubernetes and configuring clients to use it.
 
 ## Prerequisites
 
@@ -15,10 +15,10 @@ This guide walks you through deploying Citadel AI Gateway on Kubernetes and conf
 Evaluation mode enables dev login so you can explore the UI, create users, and generate API keys without configuring OIDC.
 
 ```bash
-helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
-  --set citadel.secretKey="$(openssl rand -hex 32)" \
-  --set citadel.environment=development \
-  --set citadel.devLoginEnabled=true \
+helm install corveil oci://ghcr.io/corveil/corveil-helm/corveil-chart \
+  --set corveil.secretKey="$(openssl rand -hex 32)" \
+  --set corveil.environment=development \
+  --set corveil.devLoginEnabled=true \
   --set providers.openrouter.apiKey="sk-or-v1-YOUR-KEY"
 ```
 
@@ -26,26 +26,26 @@ helm install citadel oci://ghcr.io/radiusmethod/citadel-helm/citadel-chart \
 
 | Flag | Purpose |
 |------|---------|
-| `citadel.secretKey` | Signing key for sessions and tokens. Generate a random one. |
-| `citadel.environment=development` | Enables debug-friendly behavior. |
-| `citadel.devLoginEnabled=true` | Adds a "Dev Login" button to the UI — no OIDC required. |
+| `corveil.secretKey` | Signing key for sessions and tokens. Generate a random one. |
+| `corveil.environment=development` | Enables debug-friendly behavior. |
+| `corveil.devLoginEnabled=true` | Adds a "Dev Login" button to the UI — no OIDC required. |
 | `providers.openrouter.apiKey` | Your OpenRouter API key. Get one at [openrouter.ai](https://openrouter.ai). |
 
-This deploys Citadel with a bundled PostgreSQL instance. No external database needed.
+This deploys Corveil with a bundled PostgreSQL instance. No external database needed.
 
 ## Step 2: Verify the Deployment
 
 Wait for all pods to be ready:
 
 ```bash
-kubectl get pods -l app.kubernetes.io/name=citadel -w
+kubectl get pods -l app.kubernetes.io/name=corveil -w
 ```
 
 Check health endpoints:
 
 ```bash
-# Port-forward to access Citadel locally
-kubectl port-forward svc/citadel 8000:8000 &
+# Port-forward to access Corveil locally
+kubectl port-forward svc/corveil 8000:8000 &
 
 # Liveness check
 curl -s http://localhost:8000/health | jq .
@@ -58,7 +58,7 @@ curl -s http://localhost:8000/health/ready | jq .
 
 ## Step 3: Access the UI
 
-Open the Citadel management UI:
+Open the Corveil management UI:
 
 ```bash
 open http://localhost:8000/ui
@@ -91,7 +91,7 @@ curl -s http://localhost:8000/api/keys \
 
 ## Step 5: Configure Claude Code
 
-Claude Code can use Citadel as its API backend. Configure it with:
+Claude Code can use Corveil as its API backend. Configure it with:
 
 ### Option A: Environment variables
 
@@ -120,7 +120,7 @@ Then set your API key when prompted, or via:
 
 ### Option C: Passthrough mode (Claude Code Max / own Anthropic key)
 
-If you have your own Anthropic subscription, route through Citadel for logging and guardrails while using your own auth:
+If you have your own Anthropic subscription, route through Corveil for logging and guardrails while using your own auth:
 
 ```bash
 export ANTHROPIC_BASE_URL="http://localhost:8000"
@@ -167,7 +167,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 ### Anthropic Messages API
 
-Citadel also supports the native Anthropic Messages API format:
+Corveil also supports the native Anthropic Messages API format:
 
 ```bash
 curl http://localhost:8000/v1/messages \
@@ -183,7 +183,7 @@ curl http://localhost:8000/v1/messages \
 
 ## Step 7: Provider Setup
 
-Citadel supports multiple LLM providers. Configure the ones you need:
+Corveil supports multiple LLM providers. Configure the ones you need:
 
 ### OpenRouter (recommended for getting started)
 
@@ -247,8 +247,8 @@ Before deploying to production, review this checklist:
 
 - [ ] **Set a strong `secretKey`**: `openssl rand -hex 32`
 - [ ] **Set `uiSessionSecret`** for production: `openssl rand -hex 32`
-- [ ] **Disable dev login**: `citadel.devLoginEnabled: false` (default)
-- [ ] **Set environment to production**: `citadel.environment: production` (default)
+- [ ] **Disable dev login**: `corveil.devLoginEnabled: false` (default)
+- [ ] **Set environment to production**: `corveil.environment: production` (default)
 - [ ] **Configure OIDC** (Okta) for user authentication
 - [ ] **Use `existingSecret`** with a secrets manager (Vault, Sealed Secrets, ESO) instead of plaintext values
 - [ ] **Change the PostgreSQL password** from the default `"citadel"`
@@ -272,7 +272,7 @@ Before deploying to production, review this checklist:
 ### Example production values
 
 ```yaml
-citadel:
+corveil:
   secretKey: ""  # Use existingSecret instead
   environment: production
   devLoginEnabled: false
@@ -281,7 +281,7 @@ citadel:
     domain: "company.okta.com"
     clientId: "0oaXXXXXX"
 
-existingSecret: "citadel-secrets"  # Managed by Vault/ESO
+existingSecret: "corveil-secrets"  # Managed by Vault/ESO
 
 postgresql:
   enabled: false
@@ -308,14 +308,14 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
   hosts:
-    - host: citadel.your-domain.com
+    - host: corveil.your-domain.com
       paths:
         - path: /
           pathType: Prefix
   tls:
-    - secretName: citadel-tls
+    - secretName: corveil-tls
       hosts:
-        - citadel.your-domain.com
+        - corveil.your-domain.com
 ```
 
 ## Troubleshooting
@@ -325,12 +325,12 @@ ingress:
 Check the logs:
 
 ```bash
-kubectl logs -l app.kubernetes.io/name=citadel --previous
+kubectl logs -l app.kubernetes.io/name=corveil --previous
 ```
 
 Common causes:
 - **Missing `DATABASE_URL`**: Ensure PostgreSQL is ready or external DB URL is correct
-- **Missing `SECRET_KEY`**: Set `citadel.secretKey` or provide it via `existingSecret`
+- **Missing `SECRET_KEY`**: Set `corveil.secretKey` or provide it via `existingSecret`
 - **Invalid provider credentials**: Check API keys are correct
 
 ### ImagePullBackOff
@@ -338,10 +338,10 @@ Common causes:
 The container image may not be accessible:
 
 ```bash
-kubectl describe pod -l app.kubernetes.io/name=citadel
+kubectl describe pod -l app.kubernetes.io/name=corveil
 ```
 
-- Verify image exists: `docker pull ghcr.io/radiusmethod/citadel:0.2.0`
+- Verify image exists: `docker pull ghcr.io/corveil/corveil:0.3.4`
 - For private registries, set `imagePullSecrets`
 
 ### Database connection failures
@@ -353,19 +353,19 @@ The init container waits up to 60 seconds for the database. If it times out:
 kubectl get pods -l app.kubernetes.io/name=postgresql
 
 # Check init container logs
-kubectl logs citadel-XXXXX -c wait-for-db
+kubectl logs corveil-XXXXX -c wait-for-db
 ```
 
 ### 401 Unauthorized from Claude Code
 
 1. Verify your `sk-citadel-` key is correct and active
 2. Check the key hasn't expired
-3. Ensure `ANTHROPIC_BASE_URL` points to the correct Citadel instance
-4. For passthrough mode, verify `citadel.passthrough.enabled: true`
+3. Ensure `ANTHROPIC_BASE_URL` points to the correct Corveil instance
+4. For passthrough mode, verify `corveil.passthrough.enabled: true`
 
 ### Models not showing up
 
-1. Check the models ConfigMap: `kubectl get configmap -l app.kubernetes.io/name=citadel`
+1. Check the models ConfigMap: `kubectl get configmap -l app.kubernetes.io/name=corveil`
 2. Verify provider API keys are set for the providers your models reference
 3. For custom models, ensure `modelsConfig` is correctly formatted YAML
 
@@ -375,5 +375,5 @@ This means the database is not connected. Check:
 
 ```bash
 # PostgreSQL connectivity
-kubectl exec -it citadel-XXXXX -- curl -s http://localhost:8000/health/ready
+kubectl exec -it corveil-XXXXX -- curl -s http://localhost:8000/health/ready
 ```

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,8 +1,8 @@
-Citadel AI Gateway has been deployed!
+Corveil AI Gateway has been deployed!
 
 {{- if .Values.ingress.enabled }}
 
-Access Citadel at:
+Access Corveil at:
 {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
@@ -10,23 +10,23 @@ Access Citadel at:
 {{- else if contains "NodePort" .Values.service.type }}
 
 Get the application URL:
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "citadel.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "corveil.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
 Port-forward to access the UI:
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "citadel.fullname" . }} 8000:{{ .Values.service.port }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "corveil.fullname" . }} 8000:{{ .Values.service.port }}
 
 Then open: http://localhost:8000/ui
 
 {{- end }}
 
-{{- if .Values.citadel.devLoginEnabled }}
+{{- if .Values.corveil.devLoginEnabled }}
 
 Dev login is ENABLED. Click "Dev Login" on the UI to get started.
-Disable for production: --set citadel.devLoginEnabled=false
+Disable for production: --set corveil.devLoginEnabled=false
 {{- end }}
 
 Next steps — create your first API key:
@@ -34,12 +34,12 @@ Next steps — create your first API key:
   2. Click "Create Key" and copy the generated key (starts with sk-citadel-)
   3. Configure your client:
 
-Configure Claude Code to use Citadel:
+Configure Claude Code to use Corveil:
   claude config set --global apiBaseUrl http://localhost:8000/v1
 
 Configure OpenAI-compatible clients:
   export OPENAI_API_BASE=http://localhost:8000/v1
-  export OPENAI_API_KEY=<your-citadel-api-key>
+  export OPENAI_API_KEY=<your-corveil-api-key>
 
 {{- if .Values.postgresql.enabled }}
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -31,7 +31,7 @@ Disable for production: --set corveil.devLoginEnabled=false
 
 Next steps — create your first API key:
   1. Open the UI and navigate to API Keys
-  2. Click "Create Key" and copy the generated key (starts with sk-citadel-)
+  2. Click "Create Key" and copy the generated key (starts with {{ .Values.corveil.apiKeyPrefix }}-)
   3. Configure your client:
 
 Configure Claude Code to use Corveil:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "citadel.name" -}}
+{{- define "corveil.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "citadel.fullname" -}}
+{{- define "corveil.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "citadel.chart" -}}
+{{- define "corveil.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "citadel.labels" -}}
-helm.sh/chart: {{ include "citadel.chart" . }}
-{{ include "citadel.selectorLabels" . }}
+{{- define "corveil.labels" -}}
+helm.sh/chart: {{ include "corveil.chart" . }}
+{{ include "corveil.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "citadel.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "citadel.name" . }}
+{{- define "corveil.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "corveil.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "citadel.serviceAccountName" -}}
+{{- define "corveil.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "citadel.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "corveil.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Return the name of the Secret to use.
 If existingSecret is set, use that; otherwise use release-name-secrets.
 */}}
-{{- define "citadel.secretName" -}}
+{{- define "corveil.secretName" -}}
 {{- if .Values.existingSecret }}
 {{- .Values.existingSecret }}
 {{- else }}
@@ -78,7 +78,7 @@ Build the DATABASE_URL.
 When the Bitnami PostgreSQL subchart is enabled, construct the URL from its values.
 Otherwise fall back to externalDatabase.url.
 */}}
-{{- define "citadel.databaseUrl" -}}
+{{- define "corveil.databaseUrl" -}}
 {{- if .Values.postgresql.enabled }}
 {{- $host := printf "%s-postgresql" .Release.Name }}
 {{- $port := "5432" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -74,18 +74,20 @@ If existingSecret is set, use that; otherwise use release-name-secrets.
 {{- end }}
 
 {{/*
-Build the DATABASE_URL.
-When the Bitnami PostgreSQL subchart is enabled, construct the URL from its values.
-Otherwise fall back to externalDatabase.url.
+Migration guards — fail loudly on values keys removed or renamed in chart 1.0.0
+(the Citadel → Corveil rebrand). Included from an always-rendered template so a
+stale override file produces a clear error at template time instead of a silently
+mis-secreted deploy (an ignored `citadel.secretKey` rendering an empty SECRET_KEY).
+See CHANGELOG.md [1.0.0]. Safe to remove after the 1.x line.
 */}}
-{{- define "corveil.databaseUrl" -}}
-{{- if .Values.postgresql.enabled }}
-{{- $host := printf "%s-postgresql" .Release.Name }}
-{{- $port := "5432" }}
-{{- $user := .Values.postgresql.auth.username }}
-{{- $db   := .Values.postgresql.auth.database }}
-{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s" $user $host $port $db }}
-{{- else }}
-{{- .Values.externalDatabase.url }}
+{{- define "corveil.migrationGuards" -}}
+{{- if .Values.citadel }}
+{{- fail "chart 1.0.0: the `citadel:` values block was renamed to `corveil:` — migrate your overrides (e.g. citadel.secretKey → corveil.secretKey, citadel.okta.* → corveil.okta.*). See CHANGELOG.md [1.0.0] Upgrade." }}
+{{- end }}
+{{- if and .Values.istio .Values.istio.citadel }}
+{{- fail "chart 1.0.0: the `istio.citadel:` values block was renamed to `istio.corveil:` — migrate your gateways/hosts overrides. See CHANGELOG.md [1.0.0] Upgrade." }}
+{{- end }}
+{{- if .Values.socketzero }}
+{{- fail "chart 1.0.0: the `socketzero:` values block was removed (SocketZero JWT auth is no longer bundled) — remove it from your overrides. See CHANGELOG.md [1.0.0] Removed." }}
 {{- end }}
 {{- end }}

--- a/templates/bigbang/virtualservice.yaml
+++ b/templates/bigbang/virtualservice.yaml
@@ -2,19 +2,19 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: citadel
+  name: corveil
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
-    app.kubernetes.io/part-of: citadel
-    app.kubernetes.io/component: citadel
+    {{- include "corveil.labels" . | nindent 4 }}
+    app.kubernetes.io/part-of: corveil
+    app.kubernetes.io/component: corveil
 spec:
   gateways:
-  {{- range .Values.istio.citadel.gateways }}
+  {{- range .Values.istio.corveil.gateways }}
     - {{ . }}
   {{- end }}
   hosts:
-  {{- range .Values.istio.citadel.hosts }}
+  {{- range .Values.istio.corveil.hosts }}
     - {{ tpl . $ }}
   {{- end }}
   http:
@@ -22,5 +22,5 @@ spec:
         - destination:
             port:
               number: {{ .Values.service.port }}
-            host: {{ include "citadel.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+            host: {{ include "corveil.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -3,13 +3,13 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-models
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 data:
   models.yaml: |
 {{- if .Values.modelsConfig }}
 {{ .Values.modelsConfig | indent 4 }}
 {{- else }}
-    # Citadel Model Configuration
+    # Corveil Model Configuration
     #
     # Compliance Labels:
     #   [CUI-APPROVED] - FedRAMP-compliant models hosted on AWS Bedrock GovCloud

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "citadel.fullname" . }}
+  name: {{ include "corveil.fullname" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "citadel.selectorLabels" . | nindent 6 }}
+      {{- include "corveil.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -21,7 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "citadel.selectorLabels" . | nindent 8 }}
+        {{- include "corveil.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "citadel.serviceAccountName" . }}
+      serviceAccountName: {{ include "corveil.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
@@ -76,7 +76,7 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-env
             - secretRef:
-                name: {{ include "citadel.secretName" . }}
+                name: {{ include "corveil.secretName" . }}
           ports:
             - name: http
               containerPort: 8000

--- a/templates/env.yaml
+++ b/templates/env.yaml
@@ -1,3 +1,4 @@
+{{- include "corveil.migrationGuards" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/env.yaml
+++ b/templates/env.yaml
@@ -3,18 +3,18 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-env
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 data:
-  ENVIRONMENT: {{ .Values.citadel.environment | quote }}
-  LOG_LEVEL: {{ .Values.citadel.logLevel | quote }}
-  API_KEY_PREFIX: {{ .Values.citadel.apiKeyPrefix | quote }}
-  AUTO_PROVISION_USERS: {{ .Values.citadel.autoProvisionUsers | quote }}
-  DEV_LOGIN_ENABLED: {{ .Values.citadel.devLoginEnabled | quote }}
-  GUARDRAILS_ENABLED: {{ .Values.citadel.guardrails.enabled | quote }}
-  GUARDRAIL_OPENAI_MODERATION: {{ .Values.citadel.guardrails.openaiModeration | quote }}
-  GUARDRAIL_PII_FILTER: {{ .Values.citadel.guardrails.piiFilter | quote }}
-  PASSTHROUGH_ENABLED: {{ .Values.citadel.passthrough.enabled | quote }}
-  PLUGINS_ENABLED: {{ .Values.citadel.plugins.enabled | quote }}
+  ENVIRONMENT: {{ .Values.corveil.environment | quote }}
+  LOG_LEVEL: {{ .Values.corveil.logLevel | quote }}
+  API_KEY_PREFIX: {{ .Values.corveil.apiKeyPrefix | quote }}
+  AUTO_PROVISION_USERS: {{ .Values.corveil.autoProvisionUsers | quote }}
+  DEV_LOGIN_ENABLED: {{ .Values.corveil.devLoginEnabled | quote }}
+  GUARDRAILS_ENABLED: {{ .Values.corveil.guardrails.enabled | quote }}
+  GUARDRAIL_OPENAI_MODERATION: {{ .Values.corveil.guardrails.openaiModeration | quote }}
+  GUARDRAIL_PII_FILTER: {{ .Values.corveil.guardrails.piiFilter | quote }}
+  PASSTHROUGH_ENABLED: {{ .Values.corveil.passthrough.enabled | quote }}
+  PLUGINS_ENABLED: {{ .Values.corveil.plugins.enabled | quote }}
   MODELS_CONFIG_PATH: "/app/config/models.yaml"
   MODEL_CURATION_ENABLED: "true"
   {{- /* Rate limiting */}}
@@ -24,12 +24,12 @@ data:
   LOG_REQUEST_BODY: {{ .Values.logging.requestBody | quote }}
   LOG_RESPONSE_BODY: {{ .Values.logging.responseBody | quote }}
   {{- /* OIDC / Okta */}}
-  {{- if .Values.citadel.okta.enabled }}
-  OKTA_DOMAIN: {{ .Values.citadel.okta.domain | quote }}
-  OKTA_CLIENT_ID: {{ .Values.citadel.okta.clientId | quote }}
-  UI_SESSION_EXPIRY_HOURS: {{ .Values.citadel.okta.sessionExpiryHours | quote }}
-  {{- if .Values.citadel.okta.baseUrl }}
-  UI_BASE_URL: {{ .Values.citadel.okta.baseUrl | quote }}
+  {{- if .Values.corveil.okta.enabled }}
+  OKTA_DOMAIN: {{ .Values.corveil.okta.domain | quote }}
+  OKTA_CLIENT_ID: {{ .Values.corveil.okta.clientId | quote }}
+  UI_SESSION_EXPIRY_HOURS: {{ .Values.corveil.okta.sessionExpiryHours | quote }}
+  {{- if .Values.corveil.okta.baseUrl }}
+  UI_BASE_URL: {{ .Values.corveil.okta.baseUrl | quote }}
   {{- end }}
   {{- end }}
   {{- /* SocketZero JWT */}}

--- a/templates/env.yaml
+++ b/templates/env.yaml
@@ -32,13 +32,6 @@ data:
   UI_BASE_URL: {{ .Values.corveil.okta.baseUrl | quote }}
   {{- end }}
   {{- end }}
-  {{- /* SocketZero JWT */}}
-  {{- if .Values.socketzero.enabled }}
-  TRUST_SOCKETZERO_JWT: "true"
-  SOCKETZERO_JWT_HEADER: {{ .Values.socketzero.jwtHeader | quote }}
-  SOCKETZERO_JWT_AUDIENCE: {{ .Values.socketzero.jwtAudience | quote }}
-  SOCKETZERO_JWT_ISSUER: {{ .Values.socketzero.jwtIssuer | quote }}
-  {{- end }}
   {{- /* Provider config */}}
   {{- if .Values.providers.openrouter.siteUrl }}
   OPENROUTER_SITE_URL: {{ .Values.providers.openrouter.siteUrl | quote }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "citadel.fullname" . }}
+  name: {{ include "corveil.fullname" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "citadel.fullname" . }}
+    name: {{ include "corveil.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "citadel.fullname" . -}}
+{{- $fullName := include "corveil.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -11,7 +11,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/networkpolicy.yaml
+++ b/templates/networkpolicy.yaml
@@ -2,13 +2,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "citadel.fullname" . }}
+  name: {{ include "corveil.fullname" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "citadel.selectorLabels" . | nindent 6 }}
+      {{- include "corveil.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -2,9 +2,9 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "citadel.fullname" . }}
+  name: {{ include "corveil.fullname" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
@@ -14,5 +14,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "citadel.selectorLabels" . | nindent 6 }}
+      {{- include "corveil.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "citadel.secretName" . }}
+  name: {{ include "corveil.secretName" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- if .Values.postgresql.enabled }}
@@ -12,13 +12,13 @@ stringData:
   {{- else if .Values.externalDatabase.url }}
   DATABASE_URL: {{ .Values.externalDatabase.url | quote }}
   {{- end }}
-  SECRET_KEY: {{ .Values.citadel.secretKey | quote }}
-  {{- if .Values.citadel.uiSessionSecret }}
-  UI_SESSION_SECRET: {{ .Values.citadel.uiSessionSecret | quote }}
+  SECRET_KEY: {{ .Values.corveil.secretKey | quote }}
+  {{- if .Values.corveil.uiSessionSecret }}
+  UI_SESSION_SECRET: {{ .Values.corveil.uiSessionSecret | quote }}
   {{- end }}
-  {{- if .Values.citadel.okta.enabled }}
-  OKTA_CLIENT_SECRET: {{ .Values.citadel.okta.clientSecret | quote }}
-  UI_SESSION_SECRET: {{ .Values.citadel.okta.sessionSecret | quote }}
+  {{- if .Values.corveil.okta.enabled }}
+  OKTA_CLIENT_SECRET: {{ .Values.corveil.okta.clientSecret | quote }}
+  UI_SESSION_SECRET: {{ .Values.corveil.okta.sessionSecret | quote }}
   {{- end }}
   {{- if .Values.providers.openrouter.apiKey }}
   OPENROUTER_API_KEY: {{ .Values.providers.openrouter.apiKey | quote }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- include "corveil.migrationGuards" . -}}
 {{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
@@ -12,7 +13,7 @@ stringData:
   {{- else if .Values.externalDatabase.url }}
   DATABASE_URL: {{ .Values.externalDatabase.url | quote }}
   {{- end }}
-  SECRET_KEY: {{ .Values.corveil.secretKey | quote }}
+  SECRET_KEY: {{ required "corveil.secretKey is required when existingSecret is unset — set corveil.secretKey (e.g. `openssl rand -hex 32`) or provide existingSecret." .Values.corveil.secretKey | quote }}
   {{- if .Values.corveil.uiSessionSecret }}
   UI_SESSION_SECRET: {{ .Values.corveil.uiSessionSecret | quote }}
   {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -38,7 +38,4 @@ stringData:
   {{- if .Values.externalRedis.url }}
   REDIS_URL: {{ .Values.externalRedis.url | quote }}
   {{- end }}
-  {{- if and .Values.socketzero.enabled .Values.socketzero.jwtPublicKey }}
-  SOCKETZERO_JWT_PUBLIC_KEY: {{ .Values.socketzero.jwtPublicKey | quote }}
-  {{- end }}
 {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "citadel.fullname" . }}
+  name: {{ include "corveil.fullname" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "citadel.selectorLabels" . | nindent 4 }}
+    {{- include "corveil.selectorLabels" . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "citadel.serviceAccountName" . }}
+  name: {{ include "corveil.serviceAccountName" . }}
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "citadel.fullname" . }}-test-connection"
+  name: "{{ include "corveil.fullname" . }}-test-connection"
   labels:
-    {{- include "citadel.labels" . | nindent 4 }}
+    {{- include "corveil.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
 spec:
@@ -14,10 +14,10 @@ spec:
       args:
         - |
           echo "Testing /health endpoint..."
-          wget -qO- {{ include "citadel.fullname" . }}:{{ .Values.service.port }}/health || exit 1
+          wget -qO- {{ include "corveil.fullname" . }}:{{ .Values.service.port }}/health || exit 1
           echo ""
           echo "Testing /health/ready endpoint (verifies DB connectivity)..."
-          wget -qO- {{ include "citadel.fullname" . }}:{{ .Values.service.port }}/health/ready || exit 1
+          wget -qO- {{ include "corveil.fullname" . }}:{{ .Values.service.port }}/health/ready || exit 1
           echo ""
           echo "All health checks passed."
   restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -51,14 +51,6 @@ logging:
   requestBody: true
   responseBody: true
 
-# -- SocketZero JWT authentication (keyless)
-socketzero:
-  enabled: false
-  jwtPublicKey: ""
-  jwtHeader: "X-SocketZero-Jwt-Assertion"
-  jwtAudience: "corveil"
-  jwtIssuer: "socketzero"
-
 # -- LLM Provider API keys
 providers:
   openrouter:

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-nameOverride: ""
+nameOverride: "corveil"
 fullnameOverride: "corveil"
 
 # -- Corveil application config

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Default values for Citadel AI Gateway.
+# Default values for Corveil AI Gateway.
 # This is a YAML-formatted file.
 
 domain: "bigbang.dev"
@@ -6,16 +6,16 @@ domain: "bigbang.dev"
 replicaCount: 1
 
 image:
-  repository: ghcr.io/radiusmethod/citadel
+  repository: ghcr.io/corveil/corveil
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 nameOverride: ""
-fullnameOverride: "citadel"
+fullnameOverride: "corveil"
 
-# -- Citadel application config
-citadel:
+# -- Corveil application config
+corveil:
   environment: production
   logLevel: INFO
   secretKey: ""
@@ -56,7 +56,7 @@ socketzero:
   enabled: false
   jwtPublicKey: ""
   jwtHeader: "X-SocketZero-Jwt-Assertion"
-  jwtAudience: "citadel"
+  jwtAudience: "corveil"
   jwtIssuer: "socketzero"
 
 # -- LLM Provider API keys
@@ -108,11 +108,11 @@ externalRedis:
 # -- Istio / Big Bang integration
 istio:
   enabled: false
-  citadel:
+  corveil:
     gateways:
       - "istio-system/public"
     hosts:
-      - "citadel.{{ .Values.domain }}"
+      - "corveil.{{ .Values.domain }}"
   mtls:
     mode: STRICT
 
@@ -122,7 +122,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: citadel.example.com
+    - host: corveil.example.com
       paths:
         - path: /
           pathType: Prefix
@@ -174,7 +174,7 @@ networkPolicy:
   # -- Additional egress rules (e.g., to allow specific LLM API endpoints)
   additionalEgressRules: []
 
-# -- Extra environment variables to inject into the Citadel container
+# -- Extra environment variables to inject into the Corveil container
 extraEnv: []
 # - name: MY_CUSTOM_VAR
 #   value: "my-value"
@@ -185,7 +185,7 @@ extraVolumes: []
 #   configMap:
 #     name: my-config
 
-# -- Extra volume mounts for the Citadel container
+# -- Extra volume mounts for the Corveil container
 extraVolumeMounts: []
 # - name: my-config
 #   mountPath: /app/custom-config


### PR DESCRIPTION
Closes #18.

Rebrands the chart from **Citadel** to **Corveil**, with a scalpel: the load-bearing `citadel` wire/auth contract that the Corveil app has **not** renamed is left byte-identical. Breaking key renames are now enforced with template-time guards (not just documented).

## Scope decision (Bucket B): full rename + `version 0.2.1 → 1.0.0`
Full coherent rename in one change + a `CHANGELOG.md [1.0.0]` entry with an upgrade note. `1.0.0` per the ticket's "major version bump"; reviewer noted `0.3.0` is also defensible — kept `1.0.0` (the image-tag external is now verified, see below).

## Bucket A — radiusmethod org → Corveil
GitHub URLs, `CODEOWNERS` (→ **`@dhilgaertner`**, a real user — the `@corveil/engineering` team could not be verified and a bad team ref is silently dropped), `LICENSE` (© 2026 Corveil, Inc.), `SECURITY.md`.

## Bucket D — image + chart path (overrides the ticket's stale assumption)
The app now publishes to **`ghcr.io/corveil/corveil`** (`release.yaml IMAGE_NAME=${{ github.repository }}`); `ghcr.io/radiusmethod/corveil` never existed. `image.repository` → `ghcr.io/corveil/corveil`; chart OCI → `oci://ghcr.io/corveil/corveil-helm/corveil-chart` (corveil org — matches the app image org + this repo's `GITHUB_TOKEN` scope). `appVersion 0.2.1 → 0.3.4`.

**Image tag verified:** on the `v0.3.4` tag commit (`corveil/corveil` `06e51cf`) the `build-and-push` check-run concluded **success**, so `ghcr.io/corveil/corveil:0.3.4` was published. (The package is private and my token lacks `read:packages`, so I confirmed via the publish run rather than a `docker pull`.) `release.yaml` no longer rewrites `appVersion` from the git tag, so the released chart keeps `appVersion: 0.3.4`.

## Bucket B — product/chart identity → Corveil (BREAKING)
Chart name `citadel-chart`→`corveil-chart`; `fullnameOverride`, `citadel:` / `istio.citadel:` value keys, and `citadel.*` helpers → `corveil.*`. Rendered resource names change `citadel*`→`corveil*`. CI `lint.yaml` + PR template updated.

**Migration guards (enforced, not just documented):** the chart now `fail`s at template time with a clear message if a stale `citadel:` / `istio.citadel:` / `socketzero:` override key is present, and `corveil.secretKey` is `required` when `existingSecret` is unset — so a renamed/removed key can't silently render an empty `SECRET_KEY`. The guard runs ahead of the `required` so migrating users get the rename message.

## SocketZero JWT removed (at maintainer request)
`socketzero.*` values + `TRUST_SOCKETZERO_JWT` / `SOCKETZERO_JWT_*` env vars removed. **Verified** against `corveil/corveil@main` (`dcce3e50`): zero Go references (only README + docs mention them), so the app binary doesn't consume them. Fails closed, and is guarded against stale overrides. This is a functional change riding in the rebrand PR — called out explicitly here per review.

## Bucket C — left intact (app wire/auth contract)
`sk-citadel` `apiKeyPrefix`, `x-citadel-api-key` header, all rendered env-var **names**, and the bundled-PostgreSQL `citadel` database/username/password defaults (matches the app's `docker-compose.yml`).

## Verification
- `helm lint` clean; `kube-linter` passes on CI-rendered parent templates.
- Guard/required matrix verified: clean render ok; stale `citadel` / `istio.citadel` / `socketzero` each fail with their own message; missing `secretKey` (no `existingSecret`) fails; `existingSecret` path skips it.
- Image tag `0.3.4` confirmed published via the green `build-and-push` run on the app's `v0.3.4` commit.

## Private image
`ghcr.io/corveil/corveil` is a private GHCR package (anonymous pull → 403 vs the old public image → 200). `imagePullSecrets` setup documented in `README.md` + `docs/GETTING_STARTED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
